### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # allennlp 0.9 with gradient accumulation and fp16
--e http://github.com/ibeltagy/allennlp@fp16_v0.9.0#egg=allennlp
+-e git+https://github.com/ibeltagy/allennlp@fp16_v0.9.0#egg=allennlp
 
 dill
 jsonlines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # allennlp 0.9 with gradient accumulation and fp16
--e git://github.com/ibeltagy/allennlp@fp16_v0.9.0#egg=allennlp
+-e http://github.com/ibeltagy/allennlp@fp16_v0.9.0#egg=allennlp
 
 dill
 jsonlines


### PR DESCRIPTION
In September of 2021, GitHub deprecated connections using `git://`. This PR updates the protocol used to clone the version of AllenNLP that is used for SPECTER.