### PR TITLE
Added Dockerfile for ease-of-use

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,19 @@
+# This is a dockerfile that can be used to easily host and create an environment for specter embeddings.
+FROM python:3.7-slim
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -y install git wget && apt-get -y install --upgrade build-essential
+
+RUN git clone https://github.com/allenai/specter.git
+WORKDIR "specter"
+RUN wget https://ai2-s2-research-public.s3-us-west-2.amazonaws.com/specter/archive.tar.gz && tar -xzvf archive.tar.gz
+
+RUN apt-get -y install --upgrade gcc
+RUN pip install --upgrade pip cython
+
+# A different version of allenNLP is installed to resolve dependency issues.
+RUN pip install allennlp==2.4.0
+RUN pip install -r requirements.txt
+
+RUN python setup.py install
+ENTRYPOINT /bin/bash
+


### PR DESCRIPTION
Hello maintainers,
I faced some issues with the initial setup for generating SPECTER embeddings and I noticed that there are other users that looked for a docker implementation. Hence, I have created a simple Dockerfile that can be used to start an environment to use SPECTER embeddings