### PR TITLE
Update to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 dill
 jsonlines
 pandas
-sklearn
+scikit-learn


### PR DESCRIPTION
scikit-learn can only now be installed using scikit-learn and not sklearn

Fixes the following error occurring in some CircleCI tests:
```
exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```